### PR TITLE
Migrate endpoint caching from KV to Cache API

### DIFF
--- a/server/api/heatmap.get.ts
+++ b/server/api/heatmap.get.ts
@@ -4,12 +4,11 @@ import { politicians, electorates, votes, stories, storyPoliticians } from '../d
 
 export default defineEventHandler(async (event) => {
   const db = drizzle(event.context.cloudflare.env.DB)
-  const kv = event.context.cloudflare.env.RATE_LIMIT
 
-  // Check KV cache
+  // Check cache (uses Cloudflare Cache API — free, no daily limits)
   const cacheKey = 'heatmap:data'
-  const cached = await kv.get(cacheKey)
-  if (cached) return JSON.parse(cached)
+  const cached = await getCached<any[]>(cacheKey)
+  if (cached) return cached
 
   // Fetch all current House members with their electorate and approval data
   const rows = await db
@@ -54,8 +53,8 @@ export default defineEventHandler(async (event) => {
     approvalPct: row.totalVotes > 0 ? Math.round((row.passCount / row.totalVotes) * 100) : null,
   }))
 
-  // Cache for 10 minutes
-  await kv.put(cacheKey, JSON.stringify(result), { expirationTtl: 600 })
+  // Cache for 60 minutes (Cloudflare Cache API)
+  await setCached(cacheKey, result, 3600)
 
   return result
 })

--- a/server/api/politicians/[id]/approval.get.ts
+++ b/server/api/politicians/[id]/approval.get.ts
@@ -7,13 +7,12 @@ export default defineEventHandler(async (event) => {
   if (!id) throw createError({ statusCode: 400, message: 'Invalid politician ID' })
 
   const db = drizzle(event.context.cloudflare.env.DB)
-  const kv = event.context.cloudflare.env.RATE_LIMIT
 
-  // Check KV cache first
+  // Check cache first (uses Cloudflare Cache API — free, no daily limits)
   const cacheKey = `approval:${id}`
-  const cached = await kv.get(cacheKey)
+  const cached = await getCached<{ politicianId: number, approvalPct: number | null, passCount: number, failCount: number, totalVotes: number }>(cacheKey)
   if (cached) {
-    return JSON.parse(cached)
+    return cached
   }
 
   // Verify politician exists
@@ -46,8 +45,8 @@ export default defineEventHandler(async (event) => {
 
   const response = { politicianId: id, approvalPct, passCount, failCount, totalVotes }
 
-  // Cache for 5 minutes
-  await kv.put(cacheKey, JSON.stringify(response), { expirationTtl: 300 })
+  // Cache for 30 minutes (Cloudflare Cache API)
+  await setCached(cacheKey, response, 1800)
 
   return response
 })

--- a/server/api/politicians/index.get.ts
+++ b/server/api/politicians/index.get.ts
@@ -4,7 +4,6 @@ import { politicians, electorates, votes, stories, storyPoliticians } from '../.
 
 export default defineEventHandler(async (event) => {
   const db = drizzle(event.context.cloudflare.env.DB)
-  const kv = event.context.cloudflare.env.RATE_LIMIT
 
   const query = getQuery(event) as {
     party?: string
@@ -21,12 +20,12 @@ export default defineEventHandler(async (event) => {
   const offset = (page - 1) * limit
   const sort = query.sort || 'name'
 
-  // Check KV cache for the full list (only cache unfiltered default requests)
+  // Check cache for the full list (uses Cloudflare Cache API — free, no daily limits)
   const isDefaultRequest = !query.party && !query.chamber && !query.state && !query.search && sort === 'name' && page === 1 && limit === 50
   const cacheKey = 'politicians:list'
   if (isDefaultRequest) {
-    const cached = await kv.get(cacheKey)
-    if (cached) return JSON.parse(cached)
+    const cached = await getCached<{ politicians: any[], page: number, hasMore: boolean }>(cacheKey)
+    if (cached) return cached
   }
 
   // Build WHERE conditions
@@ -123,8 +122,9 @@ export default defineEventHandler(async (event) => {
 
   const response = { politicians: result, page, hasMore: rows.length === limit }
 
+  // Cache default request for 30 minutes (Cloudflare Cache API)
   if (isDefaultRequest) {
-    await kv.put(cacheKey, JSON.stringify(response), { expirationTtl: 300 })
+    await setCached(cacheKey, response, 1800)
   }
 
   return response

--- a/server/utils/cf-cache.ts
+++ b/server/utils/cf-cache.ts
@@ -1,0 +1,50 @@
+/**
+ * Cache utility using Cloudflare Cache API.
+ *
+ * The Cache API is free with no daily operation limits, unlike KV which
+ * has a 1,000 writes/day cap on the free tier. Use this for all
+ * read-heavy caching; reserve KV for rate limiting only.
+ *
+ * Falls back to no-op in environments without the Cache API (e.g. local
+ * Node dev without wrangler).
+ */
+
+// Cloudflare Workers extends CacheStorage with a `default` property
+declare global {
+  interface CacheStorage {
+    default: Cache
+  }
+}
+
+const CACHE_PREFIX = 'https://cache.internal/'
+
+export async function getCached<T>(key: string): Promise<T | null> {
+  if (typeof caches === 'undefined') return null
+
+  try {
+    const cache = caches.default
+    const response = await cache.match(new Request(`${CACHE_PREFIX}${key}`))
+    if (!response) return null
+    return await response.json() as T
+  } catch {
+    return null
+  }
+}
+
+export async function setCached<T>(key: string, data: T, ttlSeconds: number): Promise<void> {
+  if (typeof caches === 'undefined') return
+
+  try {
+    const cache = caches.default
+    const request = new Request(`${CACHE_PREFIX}${key}`)
+    const response = new Response(JSON.stringify(data), {
+      headers: {
+        'Cache-Control': `s-maxage=${ttlSeconds}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    await cache.put(request, response)
+  } catch {
+    // Caching is best-effort — silent fail
+  }
+}


### PR DESCRIPTION
Closes #17

## Summary
- Add `server/utils/cf-cache.ts` with typed `getCached`/`setCached` helpers using Cloudflare Cache API
- Migrate heatmap, politicians list, and approval endpoints from KV to Cache API
- Bump cache TTLs (30–60 min) since Cache API has no daily operation limits
- KV reserved for rate limiting only (low write volume, appropriate use)

## Why
KV free tier has a 1,000 writes/day cap — easily hit by caching. The Cache API is free with no daily limits.

## Test plan
- [ ] Verify `wrangler dev` still works (Cache API falls back to no-op locally)
- [ ] Confirm heatmap, politicians list, and approval endpoints return correct data
- [ ] Confirm rate limiting still uses KV and works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)